### PR TITLE
Added global message buffer

### DIFF
--- a/bot.php
+++ b/bot.php
@@ -29,10 +29,14 @@ $activeActivityArray = array();
 $timerArray = array();
 $connectionAlive = false;
 $heartbeat = time();
+$messageHistoryBuffer = array(); // Circular buffer that holds the last X number of messages sent to the channel
 
 //Load the configuration specific on the command line '-c' parameter.
 $config = "";
 loadConfig();
+
+//Fill the circle message buffer with empty message arrays
+initMessageBuffer();
 
 //Set the default timezone based on the configuration file
 date_default_timezone_set($config['timezone']);
@@ -199,8 +203,7 @@ while(1) {
                 $nickaliases = serialize($nickaliases);
 
                 //Compose the insert query
-                $query = "INSERT INTO known_users (hostname,nick_aliases,last_datatype,last_message,last_location,total_words,total_lines,bot_flags,timestamp) VALUES ('".$ircdata['userhostname']."',','".$nickaliases."',','".$ircdata['messagetype']."','".$lastmessage."','".$ircdata['location']."',".$wordcount.",".$totallines.",'U','".$timestamp."')";
-                
+                $query = "INSERT INTO known_users (hostname,nick_aliases,last_datatype,last_message,last_location,total_words,total_lines,bot_flags,timestamp) VALUES ('".$ircdata['userhostname']."','".$nickaliases."','".$ircdata['messagetype']."','".$lastmessage."','".$ircdata['location']."',".$wordcount.",".$totallines.",'U','".$timestamp."')";
                 //Run the query
                 if(mysqli_query($dbconnection,$query)) {
                     logEntry("Successfully created new user record for '".$ircdata['usernickname']."@".$ircdata['userhostname']."'");
@@ -218,6 +221,11 @@ while(1) {
     //Read Chat Data - Here, we read all messages so that we can act accordingly, either by
     //watching for a command, or passive functionality that is triggered solely on content of the message
     if($ircdata['messagetype'] == "PRIVMSG" && $ircdata['location'] == $config['channel']) {
+        // Add newest message to beginning of messageHistoryBuffer
+        array_unshift($messageHistoryBuffer, array($ircdata['usernickname'], $ircdata['fullmessage']));
+        // remove oldest message from end of messageHistoryBuffer
+        array_pop($messageHistoryBuffer);
+
         //First Word - Commands are always the first word of a message, so let's isolate that word so we can check if it is a command
         //Note: If bridge support is enabled, $firstword would already be populated by that codeblock; check for that first!
         if($firstword == "") {

--- a/example.conf
+++ b/example.conf
@@ -69,6 +69,10 @@ bridge_enabled = false
 ;bridge_user_hostname_middle = "hash"
 ;bridge_user_hostname_suffix = ""
 
+; Number of messages to store in-core history buffer. 
+; Larger values may slow down some modules that use this.
+message_buffer_size = "10" 
+
 ; Triggers - Load extra triggers
 ; Triggers are a type of addon that are not invoked by a command, but are instead triggered by other means such
 ; as the bot detecting a URL in a chat message and parsing the URL to grab the page title.

--- a/lib/initMessageBuffer.php
+++ b/lib/initMessageBuffer.php
@@ -1,0 +1,17 @@
+<?php
+//This file is reponsible for initializing the circular message buffer.
+
+function initMessageBuffer(){
+    global $messageHistoryBuffer;
+    global $config;
+
+    // the message buffer is an array of arrays
+    // the arrays contained in the buffer are structure as such:
+    // $messageBufferArray = [$data['usernickname'], $data['fullmessage']]
+
+    //Init the messageBuffer with the max number of messages
+    //This way we don't have to keep track of the number of messages in the buffer, the main loop can just unshift + pop values
+    for ($i = 0; $i < (int) $config['message_buffer_size']; $i++){
+        array_unshift($messageHistoryBuffer, array([NULL, NULL])); 
+    }
+}


### PR DESCRIPTION
Updated example.conf as well to reflect new message buffer size setting. Also added new buffer init file in /lib
Also fixed the db insert query that would cause the bot to crash when ran.

the global message history buffer stores X number of user messages sent to the channel. The buffer size is set in the bot config under message_buffer_size.

The global message buffer is currently setup as an array of arrays, the sub-arrays containing the username of the sender, and the full message data from their message.

The buffer is circular and the oldest message drops off after the new one comes in.