### PR TITLE
v0.6.1 — IRC protocol fixes, JSON migration, bugfixes

### DIFF
--- a/bot.php
+++ b/bot.php
@@ -1,5 +1,5 @@
 <?php
-define('BOT_VERSION', '0.6.0');
+define('BOT_VERSION', '0.6.1');
 
 //PHP Runtime Options - These control various PHP settings like the time limit,
 //which must be 0 to allow the bot to run indefinitely.

--- a/lib/connectToServer.php
+++ b/lib/connectToServer.php
@@ -55,11 +55,11 @@ function connectToServer() {
         stream_set_blocking($socket, false);
     } else {
         stream_set_blocking($socket, false);
-        fputs($socket, "USER {$config['nickname']} 0 * :{$config['nickname']}\r\n");
         if ($config['password'] != "") {
             fputs($socket, "PASS {$config['password']}\r\n");
         }
         fputs($socket, "NICK {$config['nickname']}\r\n");
+        fputs($socket, "USER {$config['nickname']} 0 * :{$config['nickname']}\r\n");
     }
 
     sleep(1);

--- a/lib/connectToServer.php
+++ b/lib/connectToServer.php
@@ -50,12 +50,12 @@ function connectToServer() {
             fputs($socket, "PASS {$config['password']}\r\n");
         }
         fputs($socket, "NICK {$config['nickname']}\r\n");
-        fputs($socket, "USER {$config['nickname']} {$config['nickname']} {$config['nickname']} {$config['nickname']} :{$config['nickname']}\r\n");
+        fputs($socket, "USER {$config['nickname']} 0 * :{$config['nickname']}\r\n");
         _capNegotiate($useSASL, $useIRCv3);
         stream_set_blocking($socket, false);
     } else {
         stream_set_blocking($socket, false);
-        fputs($socket, "USER {$config['nickname']} {$config['nickname']} {$config['nickname']} {$config['nickname']} :{$config['nickname']}\r\n");
+        fputs($socket, "USER {$config['nickname']} 0 * :{$config['nickname']}\r\n");
         if ($config['password'] != "") {
             fputs($socket, "PASS {$config['password']}\r\n");
         }

--- a/lib/heartbeat.php
+++ b/lib/heartbeat.php
@@ -11,7 +11,7 @@ function heartbeatCheck() {
     
     $now = time();
     $diff = $now - $heartbeat;
-    if($diff > "300") {
+    if($diff > 300) {
         logEntry("Heartbeat check FAILED! Time since last successful heartbeat: ".$diff." seconds. Attempting reconnect.", 'ERROR');
         $connectionAlive = false;
         connectToServer();

--- a/lib/setMode.php
+++ b/lib/setMode.php
@@ -12,7 +12,7 @@ function setMode($direction,$mode,$user) {
     if(mysqli_num_rows($result) > 0) {
         $command = "MODE ".$config['channel']." ".$direction."".$mode." ".$user."";
         logEntry("setMode called to '".$direction."".$mode." ".$user."'", 'DEBUG');
-        fputs($socket,"$command\n");
+        fputs($socket,"$command\r\n");
     }
     return true;
 }


### PR DESCRIPTION
## Summary
- Migrates nick_aliases DB column from PHP serialize() to JSON for safety and portability
- Fixes three IRC protocol violations: USER command format (RFC 2812), CRLF in setMode (RFC 1459), PASS sent after USER/NICK in non-SASL path
- Fixes heartbeat comparison using string literal instead of integer

## Changes
- `bot.php` — serialize → json_encode/json_decode for nick_aliases; version bump to 0.6.1
- `lib/connectToServer.php` — fix USER command format; fix PASS ordering in non-SASL/non-IRCv3 path
- `lib/setMode.php` — fix \n → \r\n
- `lib/heartbeat.php` — fix `> "300"` → `> 300`

## Test plan
- [ ] Bot connects and registers correctly on a password-protected server (non-SASL)
- [ ] setMode correctly sets/unsets modes
- [ ] nick_aliases read/write correctly after migration
- [ ] Bot reconnects after heartbeat timeout