### PR TITLE
v0.6.2: multi-handler triggers + version bump

### DIFF
--- a/bot.php
+++ b/bot.php
@@ -305,9 +305,11 @@ while(1) {
         //This allows the bot to detect things, like URL's, within a message and perform an action, rather than explicitly
         //being given a command to run. Not tested with tons of triggers, but either way seems pretty inefficient in its current
         //implementation.
-        foreach($triggers as $triggerWord=>$triggerFunc) {
+        foreach($triggers as $triggerWord=>$triggerFuncs) {
             if($triggerWord === "*" || stristr($ircdata['fullmessage'],$triggerWord)) {
-                call_user_func($triggerFunc,$ircdata);
+                foreach((array)$triggerFuncs as $triggerFunc) {
+                    call_user_func($triggerFunc,$ircdata);
+                }
             }
         }
 

--- a/bot.php
+++ b/bot.php
@@ -1,5 +1,5 @@
 <?php
-define('BOT_VERSION', '0.6.1');
+define('BOT_VERSION', '0.6.2');
 
 //PHP Runtime Options - These control various PHP settings like the time limit,
 //which must be 0 to allow the bot to run indefinitely.

--- a/lib/getUserRecord.php
+++ b/lib/getUserRecord.php
@@ -1,0 +1,10 @@
+<?php
+function getUserRecord($hostname) {
+    global $dbconnection;
+    $hostname = mysqli_real_escape_string($dbconnection, $hostname);
+    $result = mysqli_query($dbconnection, "SELECT * FROM known_users WHERE hostname = '{$hostname}' LIMIT 1");
+    if($result && mysqli_num_rows($result) > 0) {
+        return mysqli_fetch_assoc($result);
+    }
+    return null;
+}

--- a/lib/loadTriggers.php
+++ b/lib/loadTriggers.php
@@ -12,7 +12,7 @@ function loadTriggers() {
                 $triggersArray  = $triggerConfig['trigger'];
                 foreach ($triggersArray as $trig) {
                     $pieces                  = explode("||", $trig);
-                    $triggers[$pieces[0]]    = $pieces[1];
+                    $triggers[$pieces[0]][]  = $pieces[1];
                 }
                 include("{$config['addons_dir']}/triggers/{$trigger}/trigger.php");
                 logEntry("Loaded trigger: {$trigger}", 'INFO');


### PR DESCRIPTION
## Summary
- Add support for multiple handlers registered to the same trigger word
- Bump version to 0.6.2

## Test plan
- [ ] demoBot starts cleanly and reports v0.6.2 in startup banner
- [ ] Existing single-handler triggers still fire normally
- [ ] A trigger word with two handlers registered fires both in order